### PR TITLE
Update Android projects to work with VS 15.7

### DIFF
--- a/src/ComputeParticles/Android/ComputeParticles.Android.csproj
+++ b/src/ComputeParticles/Android/ComputeParticles.Android.csproj
@@ -16,7 +16,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
+    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>

--- a/src/ComputeParticles/Android/ComputeParticles.Android.csproj
+++ b/src/ComputeParticles/Android/ComputeParticles.Android.csproj
@@ -97,14 +97,4 @@
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
-  <Target Name="ReplaceRefAssemblies" AfterTargets="_ResolveAssemblies">
-    <ItemGroup>
-      <ResolvedAssembliesFixedWindows Include="@(ResolvedAssemblies-&gt;Replace('\ref\','\lib\'))" />
-      <ResolvedAssembliesFixedUnix Include="@(ResolvedAssemblies-&gt;Replace('/ref/','/lib/'))" />
-      <ResolvedAssembliesFixed Include="@(ResolvedAssembliesFixedWindows)" Condition="@(ResolvedAssembliesFixedWindows) != @(ResolvedAssemblies)" />
-      <ResolvedAssembliesFixed Include="@(ResolvedAssembliesFixedUnix)" Condition="@(ResolvedAssembliesFixedUnix) != @(ResolvedAssemblies)" />
-      <ResolvedAssemblies Remove="@(ResolvedAssemblies)" />
-      <ResolvedAssemblies Include="@(ResolvedAssembliesFixed)" />
-    </ItemGroup>
-  </Target>
 </Project>

--- a/src/ComputeTexture/Android/ComputeTexture.Android.csproj
+++ b/src/ComputeTexture/Android/ComputeTexture.Android.csproj
@@ -16,7 +16,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
+    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>

--- a/src/ComputeTexture/Android/ComputeTexture.Android.csproj
+++ b/src/ComputeTexture/Android/ComputeTexture.Android.csproj
@@ -97,14 +97,4 @@
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
-  <Target Name="ReplaceRefAssemblies" AfterTargets="_ResolveAssemblies">
-    <ItemGroup>
-      <ResolvedAssembliesFixedWindows Include="@(ResolvedAssemblies-&gt;Replace('\ref\','\lib\'))" />
-      <ResolvedAssembliesFixedUnix Include="@(ResolvedAssemblies-&gt;Replace('/ref/','/lib/'))" />
-      <ResolvedAssembliesFixed Include="@(ResolvedAssembliesFixedWindows)" Condition="@(ResolvedAssembliesFixedWindows) != @(ResolvedAssemblies)" />
-      <ResolvedAssembliesFixed Include="@(ResolvedAssembliesFixedUnix)" Condition="@(ResolvedAssembliesFixedUnix) != @(ResolvedAssemblies)" />
-      <ResolvedAssemblies Remove="@(ResolvedAssemblies)" />
-      <ResolvedAssemblies Include="@(ResolvedAssembliesFixed)" />
-    </ItemGroup>
-  </Target>
 </Project>

--- a/src/Instancing/Android/Instancing.Android.csproj
+++ b/src/Instancing/Android/Instancing.Android.csproj
@@ -16,7 +16,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
+    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>

--- a/src/Instancing/Android/Instancing.Android.csproj
+++ b/src/Instancing/Android/Instancing.Android.csproj
@@ -100,14 +100,4 @@
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
-  <Target Name="ReplaceRefAssemblies" AfterTargets="_ResolveAssemblies">
-    <ItemGroup>
-      <ResolvedAssembliesFixedWindows Include="@(ResolvedAssemblies-&gt;Replace('\ref\','\lib\'))" />
-      <ResolvedAssembliesFixedUnix Include="@(ResolvedAssemblies-&gt;Replace('/ref/','/lib/'))" />
-      <ResolvedAssembliesFixed Include="@(ResolvedAssembliesFixedWindows)" Condition="@(ResolvedAssembliesFixedWindows) != @(ResolvedAssemblies)" />
-      <ResolvedAssembliesFixed Include="@(ResolvedAssembliesFixedUnix)" Condition="@(ResolvedAssembliesFixedUnix) != @(ResolvedAssemblies)" />
-      <ResolvedAssemblies Remove="@(ResolvedAssemblies)" />
-      <ResolvedAssemblies Include="@(ResolvedAssembliesFixed)" />
-    </ItemGroup>
-  </Target>
 </Project>

--- a/src/Instancing/Android/Instancing.Android.csproj
+++ b/src/Instancing/Android/Instancing.Android.csproj
@@ -96,7 +96,7 @@
       <Version>4.4.0</Version>
     </PackageReference>
     <PackageReference Include="Veldrid">
-      <Version>4.2.0-beta1</Version>
+      <Version>4.2.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />

--- a/src/SampleBase.Android/SampleBase.Android.csproj
+++ b/src/SampleBase.Android/SampleBase.Android.csproj
@@ -80,15 +80,4 @@
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
-  <!-- Workaround for https://github.com/xamarin/xamarin-android/issues/1162 -->
-  <Target Name="ReplaceRefAssemblies" AfterTargets="_ResolveAssemblies">
-    <ItemGroup>
-      <ResolvedAssembliesFixedWindows Include="@(ResolvedAssemblies-&gt;Replace('\ref\','\lib\'))" />
-      <ResolvedAssembliesFixedUnix Include="@(ResolvedAssemblies-&gt;Replace('/ref/','/lib/'))" />
-      <ResolvedAssembliesFixed Include="@(ResolvedAssembliesFixedWindows)" Condition="@(ResolvedAssembliesFixedWindows) != @(ResolvedAssemblies)" />
-      <ResolvedAssembliesFixed Include="@(ResolvedAssembliesFixedUnix)" Condition="@(ResolvedAssembliesFixedUnix) != @(ResolvedAssemblies)" />
-      <ResolvedAssemblies Remove="@(ResolvedAssemblies)" />
-      <ResolvedAssemblies Include="@(ResolvedAssembliesFixed)" />
-    </ItemGroup>
-  </Target>
 </Project>

--- a/src/SampleBase.Android/SampleBase.Android.csproj
+++ b/src/SampleBase.Android/SampleBase.Android.csproj
@@ -14,7 +14,7 @@
     <FileAlignment>512</FileAlignment>
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
+    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/SampleBase.Android/SampleBase.Android.csproj
+++ b/src/SampleBase.Android/SampleBase.Android.csproj
@@ -67,16 +67,16 @@
       <Version>4.4.0</Version>
     </PackageReference>
     <PackageReference Include="Veldrid">
-      <Version>4.2.0-beta1</Version>
+      <Version>4.2.0</Version>
     </PackageReference>
     <PackageReference Include="Veldrid.MetalBindings">
-      <Version>4.2.0-beta1</Version>
+      <Version>4.2.0</Version>
     </PackageReference>
     <PackageReference Include="Veldrid.OpenGLBindings">
-      <Version>4.2.0-beta1</Version>
+      <Version>4.2.0</Version>
     </PackageReference>
     <PackageReference Include="Veldrid.SDL2">
-      <Version>4.2.0-beta1</Version>
+      <Version>4.2.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />

--- a/src/TexturedCube/Android/TexturedCube.Android.csproj
+++ b/src/TexturedCube/Android/TexturedCube.Android.csproj
@@ -16,7 +16,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
+    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>

--- a/src/TexturedCube/Android/TexturedCube.Android.csproj
+++ b/src/TexturedCube/Android/TexturedCube.Android.csproj
@@ -102,13 +102,13 @@
       <Version>4.4.0</Version>
     </PackageReference>
     <PackageReference Include="Veldrid">
-      <Version>4.2.0-beta1</Version>
+      <Version>4.2.0</Version>
     </PackageReference>
     <PackageReference Include="Veldrid.OpenGLBindings">
-      <Version>4.2.0-beta1</Version>
+      <Version>4.2.0</Version>
     </PackageReference>
     <PackageReference Include="Veldrid.StartupUtilities">
-      <Version>4.2.0-beta1</Version>
+      <Version>4.2.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />

--- a/src/TexturedCube/Android/TexturedCube.Android.csproj
+++ b/src/TexturedCube/Android/TexturedCube.Android.csproj
@@ -112,15 +112,4 @@
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
-  <!-- Workaround for https://github.com/xamarin/xamarin-android/issues/1162 -->
-  <Target Name="ReplaceRefAssemblies" AfterTargets="_ResolveAssemblies">
-    <ItemGroup>
-      <ResolvedAssembliesFixedWindows Include="@(ResolvedAssemblies-&gt;Replace('\ref\','\lib\'))" />
-      <ResolvedAssembliesFixedUnix Include="@(ResolvedAssemblies-&gt;Replace('/ref/','/lib/'))" />
-      <ResolvedAssembliesFixed Include="@(ResolvedAssembliesFixedWindows)" Condition="@(ResolvedAssembliesFixedWindows) != @(ResolvedAssemblies)" />
-      <ResolvedAssembliesFixed Include="@(ResolvedAssembliesFixedUnix)" Condition="@(ResolvedAssembliesFixedUnix) != @(ResolvedAssemblies)" />
-      <ResolvedAssemblies Remove="@(ResolvedAssemblies)" />
-      <ResolvedAssemblies Include="@(ResolvedAssembliesFixed)" />
-    </ItemGroup>
-  </Target>
 </Project>


### PR DESCRIPTION
- TargetFramework is now explicitly set to 7.1.
``AndroidUseLatestPlatformSdk`` (the ``Use Latest Platform`` option in the project settings) is deprecated and will be removed in the future. See https://developercommunity.visualstudio.com/content/problem/253367/android-target-framework-use-latest-does-not-work.html.
- Removes the workaround for https://github.com/xamarin/xamarin-android/issues/1162, which now causes build errors and is no longer needed.
- ~~``$(VeldridVersion)`` is now used in Android projects instead of 4.2-beta1.~~ Apparently that caused warnings. Simply bumped the version to 4.2 stable instead.