### PR TITLE
Command line argument parser. TexuteCube now illustrates dynamic binding

### DIFF
--- a/src/AnimatedMesh/Desktop/Program.cs
+++ b/src/AnimatedMesh/Desktop/Program.cs
@@ -8,7 +8,7 @@ namespace AnimatedMesh
         {
             VeldridStartupWindow window = new VeldridStartupWindow("Animated Mesh");
             AnimatedMesh animatedMesh = new AnimatedMesh(window);
-            window.Run();
+            Parser.Default.ParseArguments<SampleOptions>(args).WithParsed<SampleOptions>(options => window.Run(options));
         }
     }
 }

--- a/src/ComputeParticles/Desktop/Program.cs
+++ b/src/ComputeParticles/Desktop/Program.cs
@@ -1,4 +1,5 @@
-﻿using SampleBase;
+﻿using CommandLine;
+using SampleBase;
 
 namespace ComputeParticles
 {
@@ -8,7 +9,7 @@ namespace ComputeParticles
         {
             VeldridStartupWindow window = new VeldridStartupWindow("Compute Particles");
             ComputeParticles computeParticles = new ComputeParticles(window);
-            window.Run();
+            Parser.Default.ParseArguments<SampleOptions>(args).WithParsed<SampleOptions>(options => window.Run(options));
         }
     }
 }

--- a/src/ComputeTexture/Desktop/Program.cs
+++ b/src/ComputeTexture/Desktop/Program.cs
@@ -1,4 +1,5 @@
-﻿using SampleBase;
+﻿using CommandLine;
+using SampleBase;
 
 namespace ComputeTexture
 {
@@ -8,7 +9,7 @@ namespace ComputeTexture
         {
             VeldridStartupWindow window = new VeldridStartupWindow("Compute Texture");
             ComputeTexture computeTexture = new ComputeTexture(window);
-            window.Run();
+            Parser.Default.ParseArguments<SampleOptions>(args).WithParsed<SampleOptions>(options => window.Run(options));
         }
     }
 }

--- a/src/Instancing/Desktop/Program.cs
+++ b/src/Instancing/Desktop/Program.cs
@@ -1,3 +1,4 @@
+using CommandLine;
 using SampleBase;
 
 namespace Instancing
@@ -8,7 +9,7 @@ namespace Instancing
         {
             VeldridStartupWindow window = new VeldridStartupWindow("Instancing");
             InstancingApplication instancing = new InstancingApplication(window);
-            window.Run();
+            Parser.Default.ParseArguments<SampleOptions>(args).WithParsed<SampleOptions>(options => window.Run(options));
         }
     }
 }

--- a/src/Offscreen/Desktop/Program.cs
+++ b/src/Offscreen/Desktop/Program.cs
@@ -1,3 +1,4 @@
+using CommandLine;
 using SampleBase;
 
 namespace Offscreen
@@ -8,7 +9,7 @@ namespace Offscreen
         {
             VeldridStartupWindow window = new VeldridStartupWindow("Offscreen");
             OffscreenApplication offscreen = new OffscreenApplication(window);
-            window.Run();
+            Parser.Default.ParseArguments<SampleOptions>(args).WithParsed<SampleOptions>(options => window.Run(options));
         }
     }
 }

--- a/src/SampleBase/ApplicationWindow.cs
+++ b/src/SampleBase/ApplicationWindow.cs
@@ -16,6 +16,6 @@ namespace SampleBase
         uint Width { get; }
         uint Height { get; }
 
-        void Run();
+        void Run(SampleOptions options);
     }
 }

--- a/src/SampleBase/SampleBase.csproj
+++ b/src/SampleBase/SampleBase.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.6.0" />
     <PackageReference Include="Veldrid" Version="$(VeldridVersion)" />
     <PackageReference Include="Veldrid.StartupUtilities" Version="$(VeldridVersion)" />
     <PackageReference Include="Veldrid.Utilities" Version="$(VeldridVersion)" />

--- a/src/SampleBase/SampleOptions.cs
+++ b/src/SampleBase/SampleOptions.cs
@@ -1,0 +1,11 @@
+﻿using CommandLine;
+using Veldrid;
+
+namespace SampleBase
+{
+    public class SampleOptions
+    {
+        [Option('g',"graphics", HelpText = "Graphics device. Should be equal to one of the following values: Direct3D11, Vulkan, OpenGL, Metal or OpenGLES.")]
+        public GraphicsBackend? Backend { get; set; }
+    }
+}

--- a/src/SampleBase/VeldridStartupWindow.cs
+++ b/src/SampleBase/VeldridStartupWindow.cs
@@ -43,7 +43,7 @@ namespace SampleBase
             _window.KeyDown += OnKeyDown;
         }
 
-        public void Run()
+        public void Run(SampleOptions sampleOptions)
         {
             GraphicsDeviceOptions options = new GraphicsDeviceOptions(
                 debug: false,
@@ -55,7 +55,7 @@ namespace SampleBase
 #if DEBUG
             options.Debug = true;
 #endif
-            _gd = VeldridStartup.CreateGraphicsDevice(_window, options);
+            _gd = VeldridStartup.CreateGraphicsDevice(_window, options, sampleOptions.Backend ?? VeldridStartup.GetPlatformDefaultBackend());
             _factory = new DisposeCollectorResourceFactory(_gd.ResourceFactory);
             GraphicsDeviceCreated?.Invoke(_gd, _factory, _gd.MainSwapchain);
 

--- a/src/TexturedCube/Application/TexturedCube.cs
+++ b/src/TexturedCube/Application/TexturedCube.cs
@@ -1,6 +1,7 @@
 ﻿using AssetPrimitives;
 using SampleBase;
 using System.Numerics;
+using System.Runtime.InteropServices;
 using System.Text;
 using Veldrid;
 using Veldrid.SPIRV;
@@ -25,6 +26,7 @@ namespace TexturedCube
         private ResourceSet _projViewSet;
         private ResourceSet _worldTextureSet;
         private float _ticks;
+        private uint[] _worldMatrixOffsets;
 
         public TexturedCube(ApplicationWindow window) : base(window)
         {
@@ -35,9 +37,14 @@ namespace TexturedCube
 
         protected unsafe override void CreateResources(ResourceFactory factory)
         {
+            var uniformAlignment = GraphicsDevice.UniformBufferMinOffsetAlignment;
+            var worldMatrixSize = (uint)Marshal.SizeOf<Matrix4x4>();
+            var worldMatrixUniformSize = uniformAlignment*((worldMatrixSize + uniformAlignment - 1) / uniformAlignment);
+            _worldMatrixOffsets = new uint[] {0, worldMatrixUniformSize, worldMatrixUniformSize * 2};
+
             _projectionBuffer = factory.CreateBuffer(new BufferDescription(64, BufferUsage.UniformBuffer));
             _viewBuffer = factory.CreateBuffer(new BufferDescription(64, BufferUsage.UniformBuffer));
-            _worldBuffer = factory.CreateBuffer(new BufferDescription(64, BufferUsage.UniformBuffer));
+            _worldBuffer = factory.CreateBuffer(new BufferDescription(worldMatrixUniformSize*3, BufferUsage.UniformBuffer));
 
             _vertexBuffer = factory.CreateBuffer(new BufferDescription((uint)(VertexPositionTexture.SizeInBytes * _vertices.Length), BufferUsage.VertexBuffer));
             GraphicsDevice.UpdateBuffer(_vertexBuffer, 0, _vertices);
@@ -66,7 +73,7 @@ namespace TexturedCube
 
             ResourceLayout worldTextureLayout = factory.CreateResourceLayout(
                 new ResourceLayoutDescription(
-                    new ResourceLayoutElementDescription("WorldBuffer", ResourceKind.UniformBuffer, ShaderStages.Vertex),
+                    new ResourceLayoutElementDescription("WorldBuffer", ResourceKind.UniformBuffer, ShaderStages.Vertex, ResourceLayoutElementOptions.DynamicBinding),
                     new ResourceLayoutElementDescription("SurfaceTexture", ResourceKind.TextureReadOnly, ShaderStages.Fragment),
                     new ResourceLayoutElementDescription("SurfaceSampler", ResourceKind.Sampler, ShaderStages.Fragment)));
 
@@ -114,7 +121,12 @@ namespace TexturedCube
             Matrix4x4 rotation =
                 Matrix4x4.CreateFromAxisAngle(Vector3.UnitY, (_ticks / 1000f))
                 * Matrix4x4.CreateFromAxisAngle(Vector3.UnitX, (_ticks / 3000f));
-            _cl.UpdateBuffer(_worldBuffer, 0, ref rotation);
+            for (int i = 0; i < _worldMatrixOffsets.Length; ++i)
+            {
+                Matrix4x4 translation = Matrix4x4.CreateTranslation(Vector3.UnitX*(i-1.0f)*1.4f);
+                var worldMatrix = rotation * translation;
+                _cl.UpdateBuffer(_worldBuffer, _worldMatrixOffsets[i], ref worldMatrix);
+            }
 
             _cl.SetFramebuffer(MainSwapchain.Framebuffer);
             _cl.ClearColorTarget(0, RgbaFloat.Black);
@@ -123,8 +135,12 @@ namespace TexturedCube
             _cl.SetVertexBuffer(0, _vertexBuffer);
             _cl.SetIndexBuffer(_indexBuffer, IndexFormat.UInt16);
             _cl.SetGraphicsResourceSet(0, _projViewSet);
-            _cl.SetGraphicsResourceSet(1, _worldTextureSet);
-            _cl.DrawIndexed(36, 1, 0, 0, 0);
+            for (int i = 0; i < _worldMatrixOffsets.Length; ++i)
+            {
+                _cl.SetGraphicsResourceSet(1, _worldTextureSet, 1, ref _worldMatrixOffsets[i]);
+                _cl.DrawIndexed(36, 1, 0, 0, 0);
+            }
+
 
             _cl.End();
             GraphicsDevice.SubmitCommands(_cl);

--- a/src/TexturedCube/Desktop/Program.cs
+++ b/src/TexturedCube/Desktop/Program.cs
@@ -1,4 +1,5 @@
-﻿using SampleBase;
+﻿using CommandLine;
+using SampleBase;
 
 namespace TexturedCube
 {
@@ -8,7 +9,8 @@ namespace TexturedCube
         {
             VeldridStartupWindow window = new VeldridStartupWindow("Textured Cube");
             TexturedCube texturedCube = new TexturedCube(window);
-            window.Run();
+
+            Parser.Default.ParseArguments<SampleOptions>(args).WithParsed<SampleOptions>(options => window.Run(options));
         }
     }
 }

--- a/src/TexturedCube/Desktop/TexturedCube.Desktop.csproj
+++ b/src/TexturedCube/Desktop/TexturedCube.Desktop.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
Dynamic binding seems to be broken in Direct3D11 and works fine in OpenGL and Vulkan.

Please run the TexturedCube.Desktop sample with one of the following arguments to test the issue:

-g Direct3D11
-g Vulkan
-g OpenGL