### PR TITLE
Update ImageSharp dependency to 1.0.0-beta0004 

### DIFF
--- a/src/AssetProcessor/AssetProcessor.csproj
+++ b/src/AssetProcessor/AssetProcessor.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="AssimpNet" Version="$(AssimpNetVersion)" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0003" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0004" />
     <PackageReference Include="Veldrid" Version="$(VeldridVersion)" />
     <ProjectReference Include="..\AssetPrimitives\AssetPrimitives.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Update ImageSharp dependency from 1.0.0-beta0003 to 1.0.0-beta0004 to fix AssetProcessor missing dependency.

This prevented TexturedCube from building/running using VS 2019 (from a couple of machines I've seen, old and new).

Issue highlighted here: #16 

I have not tried this change on VS 2017.
